### PR TITLE
Agrega bloquear colores durante turno de maquina

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,11 @@
+function bloquearColoresDisplay(){
+    $colores.forEach(function($color){
+        $color.onclick = function(){
+
+        }
+    });
+}
+
 function ocultarElemento(elemento){
     elemento.className = 'oculto';
 }
@@ -27,6 +35,7 @@ function pintarColor($color){
 
 
 function hacerTurnoMaquina(){
+    bloquearColoresDisplay();
     ronda ++;
     actualizarRondaDisplay(ronda);
     actualizarTurnoDisplay('Turno de la máquina');
@@ -74,6 +83,7 @@ function elegirColor(e){
 
     if($colorUsuario.id !== coloresMaquina[coloresUsuario.length - 1].id){
         actualizarTurnoDisplay('Perdiste! toca empezar para jugar nuevamente');
+        bloquearColoresDisplay();
         ronda = 0;
         coloresMaquina = [];
         coloresUsuario = [];


### PR DESCRIPTION
Porque sin esta funcionalidad, el jugador podia clickear cuando no era su turno y cuando perdía, haciendo que el juego no funcione correctamente.